### PR TITLE
Errors in PR that closed issue #166

### DIFF
--- a/src/components/Vote/NoMoreRooms.js
+++ b/src/components/Vote/NoMoreRooms.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { SafeAreaView } from "react-native-safe-area-context"
-import {View, StyleSheet, Platform} from "react-native"
+import {View } from "react-native"
 import StyledText from "../StyledText/StyledText";
 import {colors} from "../../constants/styles";
 

--- a/src/components/Vote/NoMoreRooms.js
+++ b/src/components/Vote/NoMoreRooms.js
@@ -1,0 +1,34 @@
+import React from "react"
+import { SafeAreaView } from "react-native-safe-area-context"
+import {View, StyleSheet, Platform} from "react-native"
+import StyledText from "../StyledText/StyledText";
+import {colors} from "../../constants/styles";
+
+const NoMoreRooms = () => (
+    <SafeAreaView
+        style={{
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            margin: 16
+        }}
+    >
+        <View
+            style={{
+                backgroundColor: colors.general.white,
+                padding: 32,
+                borderRadius: 20
+            }}
+        >
+            <StyledText
+                type="semibold"
+                size={32}
+                style={{color: colors.primary.main, textAlign: "center"}}
+            >
+                There are no more posts to vote on!
+            </StyledText>
+        </View>
+    </SafeAreaView>
+);
+
+export default NoMoreRooms;

--- a/src/components/Vote/Vote.js
+++ b/src/components/Vote/Vote.js
@@ -1,11 +1,8 @@
 import React, { useEffect, useState, useContext, useRef } from "react"
 import { View, StyleSheet, Platform } from "react-native"
 import VoteScreen from "./VoteScreen"
-import { SafeAreaView } from "react-native-safe-area-context"
 import fb from "../../db/init"
-import { getUserBadge } from "../../db/userBadge"
 import closeRoom from "../../db/closeRoom"
-import { StyledText } from "../StyledText"
 import { colors } from "../../constants/styles"
 import { getNumberOfVoters } from "../../db/Utility"
 import moment from "moment"
@@ -14,7 +11,6 @@ import Constants from 'expo-constants';
 import { VoteContext } from "./VoteContext/VoteContext";
 import Loader from "../FancyLoader/FancyLoader";
 import NoMoreRooms from "./NoMoreRooms";
-//const AsyncLock = require('async-lock');
 const db = fb.database();
 
 
@@ -145,7 +141,7 @@ const Vote = () => {
     </View>
   }
 
-  // We want the loading to show instead of NoMoreRooms.
+  // swiped all but new rooms are available
   if ((Object.keys(roomsNext).length!==0) && hasSwipedAll){
     return <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Loader visible={true} />

--- a/src/components/Vote/VoteContext/VoteContext.js
+++ b/src/components/Vote/VoteContext/VoteContext.js
@@ -4,7 +4,7 @@ const VoteContext = createContext();
 
 const useVote = ()=>{
       const swiper = useRef(null);
-      const [roomlist, setRoomList] = useState([]);
+      const [roomlist, setRoomList] = useState(null);
       const [currentRoom, setCurrentRoom] = useState(0);
       return {
           roomlist,

--- a/src/components/Vote/VoteScreen.js
+++ b/src/components/Vote/VoteScreen.js
@@ -86,7 +86,7 @@ const VoteScreen = ({ roomInfo }) => {
 
 
   return roomData && isLoggedIn ? (
-    <Surface style={{ height: "96%", borderRadius: 30, borderWidth: .5, borderColor: 'rgba(0,0,0,.5)' }}>
+    <Surface style={{ height: "96%", borderRadius: 30, borderWidth: .5, borderColor: 'rgba(0,0,0,.1)' }}>
       <View >
         <View style={styles.container}>
           {/*


### PR DESCRIPTION
- A user would be stuck on loading screen if they made a selection for every vote card and there were no rooms left to vote on-- 'no rooms' message would not appear.
- If user A clicked through all the cards, and then another user B created a new room, then userA would not see this new room; userA would be stuck on loading screen
- If roomList =[] initially for user A, and then userB created a new room, then userA would not see this new room; userA would see the 'no rooms' message
- The tinder swiper package could not deal with a empty array (when roomList=[]), it was throwing errors
- VoteContext initially set roomList=[] instead of null so line 142 in VoteScreen never fired.

All  fixed closes #166 

Since roomNext gets a new room right when a new room is created the sort doesn't really do anything since no one has voted since the roomm is brand new. If people vote before we call `getActiveList()` on `roomNext` the sort wont pick that up either cuz getActiveList() isnt pulling from db anymore. This doesn't matter but could be fixed